### PR TITLE
fix: use Prefect 3.0+ compatible FlowHook for failure handler

### DIFF
--- a/pipelines/trading_flow.py
+++ b/pipelines/trading_flow.py
@@ -200,7 +200,7 @@ def market_is_open(today: dt.date) -> bool:
     return len(schedule) > 0
 
 
-@flow(on_failure=create_failure_handler("trading_daily_flow"))
+@flow(on_failure=[create_failure_handler("trading_daily_flow")])
 def trading_daily_flow():
     trade_start_time = dt.datetime.now()
 

--- a/pipelines/utils/slack_failure_handler.py
+++ b/pipelines/utils/slack_failure_handler.py
@@ -1,10 +1,11 @@
-"""Slack failure handler for Prefect flows."""
+"""Slack failure handler for Prefect flows using hook pattern."""
 
 import os
 import traceback
 from typing import Optional
 
 from clients import get_slack_client
+from prefect.flows import FlowHook
 from slack_sdk.errors import SlackApiError
 
 
@@ -97,31 +98,40 @@ def send_flow_failure_notification(
         raise
 
 
-def create_failure_handler(flow_name: str):
-    """
-    Create a flow-level failure handler for a Prefect flow.
+class SlackFailureHook(FlowHook):
+    """Prefect FlowHook that sends Slack notifications on flow failure."""
     
-    Usage:
-        @flow(on_failure=create_failure_handler("my_flow"))
-        def my_flow():
-            ...
+    def __init__(self, flow_name: str):
+        """
+        Initialize the hook with a flow name.
+        
+        Args:
+            flow_name: Name of the flow for Slack messages
+        """
+        super().__init__()
+        self.flow_name = flow_name
     
-    Args:
-        flow_name: Name of the flow (for the Slack message)
-    
-    Returns:
-        A callable handler function for use with @flow decorator
-    """
-    def failure_handler(flow, flow_run, state):
-        """Handle flow failure and send Slack notification."""
+    async def hook_fn(self, flow, flow_run, state):
+        """
+        Hook function called when a flow fails.
+        
+        Args:
+            flow: The Prefect Flow object
+            flow_run: The Prefect FlowRun object
+            state: The state object containing failure info
+        """
         try:
-            # Extract error info from the state
-            error = state.result(raise_on_failure=False)
-            if isinstance(error, Exception):
-                exc = error
+            # Extract error from the state
+            # In Prefect 3.0+, failed states have exception info
+            if state.result(raise_on_failure=False):
+                # Try to get the actual exception
+                exc = state.result(raise_on_failure=False)
+                if isinstance(exc, Exception):
+                    error = exc
+                else:
+                    error = Exception(str(exc))
             else:
-                # If not an exception, try to get the traceback from the state
-                exc = Exception(str(error))
+                error = Exception("Unknown error")
             
             # Build context info
             context = {
@@ -129,9 +139,25 @@ def create_failure_handler(flow_name: str):
                 "parameters": flow_run.parameters if flow_run else {},
             }
             
-            send_flow_failure_notification(flow_name, exc, context)
+            send_flow_failure_notification(self.flow_name, error, context)
         except Exception as e:
             # Don't let the handler failure break the flow
-            print(f"Error in failure handler: {e}")
+            print(f"Error in Slack failure hook: {e}")
+
+
+def create_failure_handler(flow_name: str) -> SlackFailureHook:
+    """
+    Create a Slack failure hook for a Prefect flow.
     
-    return failure_handler
+    Usage:
+        @flow(on_failure=[create_failure_handler("my_flow")])
+        def my_flow():
+            ...
+    
+    Args:
+        flow_name: Name of the flow (for the Slack message)
+    
+    Returns:
+        A SlackFailureHook instance
+    """
+    return SlackFailureHook(flow_name)


### PR DESCRIPTION
## Problem
Deployment failed with:
```
TypeError: Expected iterable for 'on_failure'; got function instead. 
Please provide a list of hooks to 'on_failure': @flow(on_failure=[hook1, hook2])
```

Prefect 3.0+ requires `on_failure` to accept a list of FlowHook objects, not plain functions.

## Solution
- Convert `SlackFailureHook` to proper `FlowHook` subclass with async `hook_fn`
- Pass handler as list: `@flow(on_failure=[...])`
- Maintains all existing functionality (traceback, context, Slack notification)

## Testing
This should now deploy cleanly on Railway without the TypeError.