### PR TITLE
fix: rewrite stock_prices_yfinance_flow with proper MultiIndex handling

### DIFF
--- a/pipelines/stock_prices_yfinance_flow.py
+++ b/pipelines/stock_prices_yfinance_flow.py
@@ -1,108 +1,248 @@
-from clients import get_clickhouse_client
 import datetime as dt
+
+import bear_lake as bl
 import polars as pl
-from prefect import flow, task, get_run_logger
-from variables import TIME_ZONE
 import yfinance as yf
+from clients import get_bear_lake_client
+from prefect import flow, get_run_logger, task
 from utils import get_last_market_date
+from variables import TIME_ZONE
 
 
-def to_yfinance_ticker(ticker: str) -> str:
-    """Convert database ticker to yfinance format (BF.B -> BF-B)"""
-    return ticker.replace(".", "-")
-
-
-def to_db_ticker(yf_ticker: str) -> str:
-    """Convert yfinance ticker back to database format (BF-B -> BF.B)"""
-    return yf_ticker.replace("-", ".")
+def _empty_schema() -> dict:
+    """Return the expected schema for an empty DataFrame."""
+    return {
+        "ticker": pl.String,
+        "date": pl.Date,
+        "open": pl.Float64,
+        "high": pl.Float64,
+        "low": pl.Float64,
+        "close": pl.Float64,
+        "volume": pl.Float64,
+    }
 
 
 @task
-def get_tickers() -> list[str]:
-    clickhouse_client = get_clickhouse_client()
-
-    universe_arrow = clickhouse_client.query_arrow(
-        f"SELECT DISTINCT ticker FROM universe"
+def get_tickers_with_date_range() -> pl.DataFrame:
+    """Get tickers with their date ranges from universe."""
+    bear_lake_client = get_bear_lake_client()
+    return bear_lake_client.query(
+        bl.table("universe")
+        .group_by("ticker")
+        .agg(
+            bl.col("date").min().alias("min_date"),
+            bl.col("date").max().alias("max_date"),
+        )
     )
-
-    return pl.from_arrow(universe_arrow)["ticker"].sort().to_list()
 
 
 @task
 def get_stock_prices_yfinance(
-    tickers: list[str], start: dt.datetime, end: dt.datetime
+    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime
 ) -> pl.DataFrame:
     """
     Fetch historical stock prices from yfinance.
-    Returns data in the same schema as Alpaca, with vwap and trade_count as null.
+    Uses date ranges from universe to skip delisted tickers and cap end dates.
     """
     logger = get_run_logger()
 
-    try:
-        # yfinance expects dates without timezone, so convert to naive datetime
-        start_naive = start.replace(tzinfo=None)
-        end_naive = end.replace(tzinfo=None)
+    if tickers_df.is_empty():
+        return pl.DataFrame(schema=_empty_schema())
 
-        # Convert tickers to yfinance format (BF.B -> BF-B)
-        yf_tickers = [to_yfinance_ticker(t) for t in tickers]
+    # Convert to naive datetime (yfinance expects dates without timezone)
+    start_naive = start.replace(tzinfo=None)
+    end_naive = end.replace(tzinfo=None)
 
-        # Download data for all tickers at once
-        data_raw = yf.download(tickers=yf_tickers, start=start_naive, end=end_naive)
+    all_data = []
+    skipped = 0
+    fetched = 0
 
-        if data_raw.empty:
-            return pl.DataFrame(
-                schema={
-                    "ticker": pl.String,
-                    "date": pl.String,
-                    "open": pl.Float64,
-                    "high": pl.Float64,
-                    "low": pl.Float64,
-                    "close": pl.Float64,
-                    "volume": pl.Float64,
-                }
+    for row in tickers_df.iter_rows(named=True):
+        ticker = row["ticker"]
+        max_date = row["max_date"]
+
+        # Skip if we're requesting data after this ticker was delisted
+        if start.date() > max_date:
+            skipped += 1
+            continue
+
+        # Cap the end date to when the ticker was last active
+        effective_end_date = min(end.date(), max_date)
+        effective_end_naive = dt.datetime.combine(
+            effective_end_date, dt.time(23, 59, 59)
+        )
+
+        try:
+            # Download single ticker
+            data = yf.download(
+                tickers=ticker,
+                start=start_naive,
+                end=effective_end_naive,
+                progress=False,
+                auto_adjust=True,
             )
 
-        # Stack and reset index to get long format
-        data_clean = data_raw.stack(future_stack=True).reset_index()
+            if data.empty:
+                continue
 
-        # Convert to polars
-        hist_df = pl.from_pandas(data_clean)
+            # Reset index to get Date as a column
+            data = data.reset_index()
 
-        # Rename columns to match schema and convert tickers back to db format
-        stock_prices_clean = hist_df.select(
-            pl.col("Ticker").map_elements(to_db_ticker, return_dtype=pl.String).alias("ticker"),
-            pl.col("Date").dt.date().cast(pl.String).alias("date"),
-            pl.col("Open").alias("open"),
-            pl.col("High").alias("high"),
-            pl.col("Low").alias("low"),
-            pl.col("Close").alias("close"),
-            pl.col("Volume").cast(pl.Float64).alias("volume"),
-        )
+            # Convert to polars and add ticker column
+            ticker_df = pl.from_pandas(data).select(
+                pl.lit(ticker).alias("ticker"),
+                pl.col("Date").dt.date().alias("date"),
+                pl.col("Open").alias("open"),
+                pl.col("High").alias("high"),
+                pl.col("Low").alias("low"),
+                pl.col("Close").alias("close"),
+                pl.col("Volume").cast(pl.Float64).alias("volume"),
+            )
 
-        return stock_prices_clean.sort("date", "ticker")
+            all_data.append(ticker_df)
+            fetched += 1
 
-    except Exception as e:
-        logger.error(f"Error fetching data: {e}")
-        return pl.DataFrame(
-            schema={
-                "ticker": pl.String,
-                "date": pl.String,
-                "open": pl.Float64,
-                "high": pl.Float64,
-                "low": pl.Float64,
-                "close": pl.Float64,
-                "volume": pl.Float64,
-            }
-        )
+        except Exception as e:
+            logger.warning(f"Failed to fetch {ticker}: {e}")
+            continue
+
+    logger.info(f"Fetched {fetched} tickers, skipped {skipped} delisted")
+
+    if not all_data:
+        return pl.DataFrame(schema=_empty_schema())
+
+    return pl.concat(all_data).sort("date", "ticker")
 
 
 @task
-def get_stock_prices_yfinance_batches(
-    tickers: list[str], start: dt.datetime, end: dt.datetime
+def get_stock_prices_yfinance_batch(
+    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime, batch_size: int = 50
 ) -> pl.DataFrame:
     """
-    Fetch stock prices in batches by year using yf.download().
+    Fetch stock prices using yf.download() with batched tickers.
+    Uses date ranges from universe to filter and cap dates appropriately.
     """
+    logger = get_run_logger()
+
+    if tickers_df.is_empty():
+        return pl.DataFrame(schema=_empty_schema())
+
+    start_naive = start.replace(tzinfo=None)
+    end_naive = end.replace(tzinfo=None)
+
+    # Filter to only tickers active during this period
+    active_tickers_df = tickers_df.filter(pl.col("max_date") >= start.date())
+    
+    if active_tickers_df.is_empty():
+        logger.info(f"No active tickers for period {start.date()} to {end.date()}")
+        return pl.DataFrame(schema=_empty_schema())
+
+    # Build a lookup for max_date by ticker
+    max_date_lookup = {
+        row["ticker"]: row["max_date"] 
+        for row in active_tickers_df.iter_rows(named=True)
+    }
+    
+    tickers = list(max_date_lookup.keys())
+    logger.info(f"Fetching {len(tickers)} active tickers (filtered from {len(tickers_df)})")
+
+    all_data = []
+
+    # Process in batches
+    for i in range(0, len(tickers), batch_size):
+        batch = tickers[i : i + batch_size]
+        logger.info(f"Fetching batch {i // batch_size + 1}: {len(batch)} tickers")
+
+        try:
+            # Download batch of tickers
+            data = yf.download(
+                tickers=batch,
+                start=start_naive,
+                end=end_naive,
+                progress=False,
+                auto_adjust=True,
+                group_by="ticker",
+            )
+
+            if data.empty:
+                continue
+
+            # Handle single ticker case (no MultiIndex)
+            if len(batch) == 1:
+                ticker = batch[0]
+                max_date = max_date_lookup[ticker]
+                data = data.reset_index()
+                
+                ticker_df = pl.from_pandas(data).select(
+                    pl.lit(ticker).alias("ticker"),
+                    pl.col("Date").dt.date().alias("date"),
+                    pl.col("Open").alias("open"),
+                    pl.col("High").alias("high"),
+                    pl.col("Low").alias("low"),
+                    pl.col("Close").alias("close"),
+                    pl.col("Volume").cast(pl.Float64).alias("volume"),
+                )
+                
+                # Filter to only dates up to max_date
+                ticker_df = ticker_df.filter(pl.col("date") <= max_date)
+                
+                if not ticker_df.is_empty():
+                    all_data.append(ticker_df)
+                continue
+
+            # Handle multiple tickers (MultiIndex columns grouped by ticker)
+            for ticker in batch:
+                try:
+                    if ticker not in data.columns.get_level_values(0):
+                        continue
+
+                    max_date = max_date_lookup[ticker]
+                    ticker_data = data[ticker].copy()
+                    ticker_data = ticker_data.reset_index()
+
+                    if ticker_data.empty or ticker_data["Close"].isna().all():
+                        continue
+
+                    ticker_df = pl.from_pandas(ticker_data).select(
+                        pl.lit(ticker).alias("ticker"),
+                        pl.col("Date").dt.date().alias("date"),
+                        pl.col("Open").alias("open"),
+                        pl.col("High").alias("high"),
+                        pl.col("Low").alias("low"),
+                        pl.col("Close").alias("close"),
+                        pl.col("Volume").cast(pl.Float64).alias("volume"),
+                    )
+
+                    # Filter to only dates up to max_date and drop nulls
+                    ticker_df = ticker_df.filter(pl.col("date") <= max_date).drop_nulls(
+                        subset=["close"]
+                    )
+
+                    if not ticker_df.is_empty():
+                        all_data.append(ticker_df)
+
+                except Exception as e:
+                    logger.warning(f"Failed to process {ticker} in batch: {e}")
+                    continue
+
+        except Exception as e:
+            logger.error(f"Failed to fetch batch: {e}")
+            continue
+
+    if not all_data:
+        return pl.DataFrame(schema=_empty_schema())
+
+    return pl.concat(all_data).sort("date", "ticker")
+
+
+@task
+def get_stock_prices_yfinance_by_year(
+    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime
+) -> pl.DataFrame:
+    """
+    Fetch stock prices in batches by year.
+    """
+    logger = get_run_logger()
     years = range(start.year, end.year + 1)
     stock_prices_list = []
 
@@ -110,67 +250,64 @@ def get_stock_prices_yfinance_batches(
         year_start = max(dt.datetime(year, 1, 1, 0, 0, 0, tzinfo=TIME_ZONE), start)
         year_end = min(dt.datetime(year, 12, 31, 23, 59, 59, tzinfo=TIME_ZONE), end)
 
-        stock_prices = get_stock_prices_yfinance(tickers, year_start, year_end)
+        logger.info(f"Fetching year {year}: {year_start.date()} to {year_end.date()}")
+
+        stock_prices = get_stock_prices_yfinance_batch(tickers_df, year_start, year_end)
 
         if not stock_prices.is_empty():
             stock_prices_list.append(stock_prices)
 
     if not stock_prices_list:
-        return pl.DataFrame(
-            schema={
-                "ticker": pl.String,
-                "date": pl.String,
-                "open": pl.Float64,
-                "high": pl.Float64,
-                "low": pl.Float64,
-                "close": pl.Float64,
-                "volume": pl.Float64,
-            }
-        )
+        return pl.DataFrame(schema=_empty_schema())
 
-    return pl.concat(stock_prices_list).sort("date", "ticker")
+    return (
+        pl.concat(stock_prices_list)
+        .unique(subset=["ticker", "date"])
+        .with_columns(pl.col("date").dt.year().alias("year"))
+        .sort("date", "ticker")
+    )
 
 
-# based on existing patterns in other jobs
 @task
 def upload_and_merge_stock_prices_yfinance_df(stock_prices_df: pl.DataFrame):
-    clickhouse_client = get_clickhouse_client()
+    bear_lake_client = get_bear_lake_client()
     table_name = "stock_prices_yfinance"
 
     # Create table if not exists
-    clickhouse_client.command(
-        f"""
-        CREATE TABLE IF NOT EXISTS {table_name} (
-            ticker String,
-            date String,
-            open Float64,
-            high Float64,
-            low Float64,
-            close Float64,
-            volume Float64
-        )
-        ENGINE = ReplacingMergeTree()
-        ORDER BY (ticker, date)
-        """
+    bear_lake_client.create(
+        name=table_name,
+        schema={
+            "ticker": pl.String,
+            "date": pl.Date,
+            "open": pl.Float64,
+            "high": pl.Float64,
+            "low": pl.Float64,
+            "close": pl.Float64,
+            "volume": pl.Float64,
+        },
+        partition_keys=["year"],
+        primary_keys=["date", "ticker"],
+        mode="skip",
     )
 
     # Insert into table
-    clickhouse_client.insert_df_arrow(table_name, stock_prices_df)
+    bear_lake_client.insert(name=table_name, data=stock_prices_df, mode="append")
 
     # Optimize table (deduplicate)
-    clickhouse_client.command(f"OPTIMIZE TABLE {table_name} FINAL")
+    bear_lake_client.optimize(name=table_name)
 
 
 @flow
 def stock_prices_yfinance_backfill_flow():
     """
     Grabbing yfinance data from 2000 to present day.
+    Uses universe date ranges to avoid fetching data for delisted tickers.
     """
     start = dt.datetime(2000, 1, 1, tzinfo=TIME_ZONE)
-    end = dt.datetime.now(TIME_ZONE)
+    end = dt.datetime.now(TIME_ZONE) - dt.timedelta(days=1)
 
-    tickers = get_tickers()
-    stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
+    tickers_df = get_tickers_with_date_range()
+    stock_prices_df = get_stock_prices_yfinance_by_year(tickers_df, start, end)
     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
 
 
@@ -189,6 +326,6 @@ def stock_prices_yfinance_daily_flow():
     start = dt.datetime.combine(yesterday, dt.time(0, 0, 0)).replace(tzinfo=TIME_ZONE)
     end = dt.datetime.combine(yesterday, dt.time(23, 59, 59)).replace(tzinfo=TIME_ZONE)
 
-    tickers = get_tickers()
-    stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
+    tickers_df = get_tickers_with_date_range()
+    stock_prices_df = get_stock_prices_yfinance_by_year(tickers_df, start, end)
     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)

--- a/pipelines/stock_prices_yfinance_flow.py
+++ b/pipelines/stock_prices_yfinance_flow.py
@@ -1,181 +1,282 @@
-# from clients import get_clickhouse_client
-# import datetime as dt
-# import polars as pl
-# from prefect import flow, task, get_run_logger
-# from variables import TIME_ZONE
-# import yfinance as yf
-# from utils import get_last_market_date
+import datetime as dt
+
+import bear_lake as bl
+import polars as pl
+import yfinance as yf
+from clients import get_bear_lake_client
+from prefect import flow, get_run_logger, task
+from utils import get_last_market_date
+from variables import TIME_ZONE
 
 
-# @task
-# def get_tickers() -> list[str]:
-#     clickhouse_client = get_clickhouse_client()
-
-#     universe_arrow = clickhouse_client.query_arrow(
-#         f"SELECT DISTINCT ticker FROM universe"
-#     )
-
-#     return pl.from_arrow(universe_arrow)["ticker"].sort().to_list()
-
-
-# @task
-# def get_stock_prices_yfinance(
-#     tickers: list[str], start: dt.datetime, end: dt.datetime
-# ) -> pl.DataFrame:
-#     """
-#     Fetch historical stock prices from yfinance.
-#     Returns data in the same schema as Alpaca, with vwap and trade_count as null.
-#     """
-#     logger = get_run_logger()
-
-#     try:
-#         # yfinance expects dates without timezone, so convert to naive datetime
-#         start_naive = start.replace(tzinfo=None)
-#         end_naive = end.replace(tzinfo=None)
-
-#         # Download data for all tickers at once
-#         data_raw = yf.download(tickers=tickers, start=start_naive, end=end_naive)
-
-#         if data_raw.empty:
-#             return pl.DataFrame(
-#                 schema={
-#                     "ticker": pl.String,
-#                     "date": pl.String,
-#                     "open": pl.Float64,
-#                     "high": pl.Float64,
-#                     "low": pl.Float64,
-#                     "close": pl.Float64,
-#                     "volume": pl.Float64,
-#                 }
-#             )
-
-#         # Stack and reset index to get long format
-#         data_clean = data_raw.stack(future_stack=True).reset_index()
-
-#         # Convert to polars
-#         hist_df = pl.from_pandas(data_clean)
-
-#         # Rename columns to match schema
-#         stock_prices_clean = hist_df.select(
-#             pl.col("Ticker").alias("ticker"),
-#             pl.col("Date").dt.date().cast(pl.String).alias("date"),
-#             pl.col("Open").alias("open"),
-#             pl.col("High").alias("high"),
-#             pl.col("Low").alias("low"),
-#             pl.col("Close").alias("close"),
-#             pl.col("Volume").cast(pl.Float64).alias("volume"),
-#         )
-
-#         return stock_prices_clean.sort("date", "ticker")
-
-#     except Exception as e:
-#         logger.error(f"Error fetching data: {e}")
-#         return pl.DataFrame(
-#             schema={
-#                 "ticker": pl.String,
-#                 "date": pl.String,
-#                 "open": pl.Float64,
-#                 "high": pl.Float64,
-#                 "low": pl.Float64,
-#                 "close": pl.Float64,
-#                 "volume": pl.Float64,
-#             }
-#         )
+@task
+def get_tickers() -> list[str]:
+    bear_lake_client = get_bear_lake_client()
+    return (
+        bear_lake_client.query(bl.table("universe").select("ticker").unique())["ticker"]
+        .sort()
+        .to_list()
+    )
 
 
-# @task
-# def get_stock_prices_yfinance_batches(
-#     tickers: list[str], start: dt.datetime, end: dt.datetime
-# ) -> pl.DataFrame:
-#     """
-#     Fetch stock prices in batches by year using yf.download().
-#     """
-#     years = range(start.year, end.year + 1)
-#     stock_prices_list = []
-
-#     for year in years:
-#         year_start = max(dt.datetime(year, 1, 1, 0, 0, 0, tzinfo=TIME_ZONE), start)
-#         year_end = min(dt.datetime(year, 12, 31, 23, 59, 59, tzinfo=TIME_ZONE), end)
-
-#         stock_prices = get_stock_prices_yfinance(tickers, year_start, year_end)
-
-#         if not stock_prices.is_empty():
-#             stock_prices_list.append(stock_prices)
-
-#     if not stock_prices_list:
-#         return pl.DataFrame(
-#             schema={
-#                 "ticker": pl.String,
-#                 "date": pl.String,
-#                 "open": pl.Float64,
-#                 "high": pl.Float64,
-#                 "low": pl.Float64,
-#                 "close": pl.Float64,
-#                 "volume": pl.Float64,
-#             }
-#         )
-
-#     return pl.concat(stock_prices_list).sort("date", "ticker")
+def _empty_schema() -> dict:
+    """Return the expected schema for an empty DataFrame."""
+    return {
+        "ticker": pl.String,
+        "date": pl.Date,
+        "open": pl.Float64,
+        "high": pl.Float64,
+        "low": pl.Float64,
+        "close": pl.Float64,
+        "volume": pl.Float64,
+    }
 
 
-# # based on existing patterns in other jobs
-# @task
-# def upload_and_merge_stock_prices_yfinance_df(stock_prices_df: pl.DataFrame):
-#     clickhouse_client = get_clickhouse_client()
-#     table_name = "stock_prices_yfinance"
+@task
+def get_stock_prices_yfinance(
+    tickers: list[str], start: dt.datetime, end: dt.datetime
+) -> pl.DataFrame:
+    """
+    Fetch historical stock prices from yfinance.
+    Downloads each ticker individually to avoid MultiIndex complexity.
+    """
+    logger = get_run_logger()
 
-#     # Create table if not exists
-#     clickhouse_client.command(
-#         f"""
-#         CREATE TABLE IF NOT EXISTS {table_name} (
-#             ticker String,
-#             date String,
-#             open Float64,
-#             high Float64,
-#             low Float64,
-#             close Float64,
-#             volume Float64
-#         )
-#         ENGINE = ReplacingMergeTree()
-#         ORDER BY (ticker, date)
-#         """
-#     )
+    if not tickers:
+        return pl.DataFrame(schema=_empty_schema())
 
-#     # Insert into table
-#     clickhouse_client.insert_df_arrow(table_name, stock_prices_df)
+    # Convert to naive datetime (yfinance expects dates without timezone)
+    start_naive = start.replace(tzinfo=None)
+    end_naive = end.replace(tzinfo=None)
 
-#     # Optimize table (deduplicate)
-#     clickhouse_client.command(f"OPTIMIZE TABLE {table_name} FINAL")
+    all_data = []
+
+    for ticker in tickers:
+        try:
+            # Download single ticker - returns simple DataFrame
+            data = yf.download(
+                tickers=ticker,
+                start=start_naive,
+                end=end_naive,
+                progress=False,
+                auto_adjust=True,  # Use adjusted prices
+            )
+
+            if data.empty:
+                continue
+
+            # Reset index to get Date as a column
+            data = data.reset_index()
+
+            # Convert to polars and add ticker column
+            ticker_df = pl.from_pandas(data).select(
+                pl.lit(ticker).alias("ticker"),
+                pl.col("Date").dt.date().alias("date"),
+                pl.col("Open").alias("open"),
+                pl.col("High").alias("high"),
+                pl.col("Low").alias("low"),
+                pl.col("Close").alias("close"),
+                pl.col("Volume").cast(pl.Float64).alias("volume"),
+            )
+
+            all_data.append(ticker_df)
+
+        except Exception as e:
+            logger.warning(f"Failed to fetch {ticker}: {e}")
+            continue
+
+    if not all_data:
+        return pl.DataFrame(schema=_empty_schema())
+
+    return pl.concat(all_data).sort("date", "ticker")
 
 
-# @flow
-# def stock_prices_yfinance_backfill_flow():
-#     """
-#     Grabbing yfinance data from 2000 to present day.
-#     """
-#     start = dt.datetime(2000, 1, 1, tzinfo=TIME_ZONE)
-#     end = dt.datetime.now(TIME_ZONE)
+@task
+def get_stock_prices_yfinance_batch(
+    tickers: list[str], start: dt.datetime, end: dt.datetime, batch_size: int = 50
+) -> pl.DataFrame:
+    """
+    Fetch stock prices using yf.download() with batched tickers.
+    More efficient than individual downloads but handles MultiIndex properly.
+    """
+    logger = get_run_logger()
 
-#     tickers = get_tickers()
-#     stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
-#     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
+    if not tickers:
+        return pl.DataFrame(schema=_empty_schema())
+
+    start_naive = start.replace(tzinfo=None)
+    end_naive = end.replace(tzinfo=None)
+
+    all_data = []
+
+    # Process in batches to avoid overwhelming the API
+    for i in range(0, len(tickers), batch_size):
+        batch = tickers[i : i + batch_size]
+        logger.info(f"Fetching batch {i // batch_size + 1}: {len(batch)} tickers")
+
+        try:
+            # Download batch of tickers
+            data = yf.download(
+                tickers=batch,
+                start=start_naive,
+                end=end_naive,
+                progress=False,
+                auto_adjust=True,
+                group_by="ticker",  # Group by ticker for easier processing
+            )
+
+            if data.empty:
+                continue
+
+            # Handle single ticker case (no MultiIndex)
+            if len(batch) == 1:
+                ticker = batch[0]
+                data = data.reset_index()
+                ticker_df = pl.from_pandas(data).select(
+                    pl.lit(ticker).alias("ticker"),
+                    pl.col("Date").dt.date().alias("date"),
+                    pl.col("Open").alias("open"),
+                    pl.col("High").alias("high"),
+                    pl.col("Low").alias("low"),
+                    pl.col("Close").alias("close"),
+                    pl.col("Volume").cast(pl.Float64).alias("volume"),
+                )
+                all_data.append(ticker_df)
+                continue
+
+            # Handle multiple tickers (MultiIndex columns grouped by ticker)
+            for ticker in batch:
+                try:
+                    if ticker not in data.columns.get_level_values(0):
+                        continue
+
+                    ticker_data = data[ticker].copy()
+                    ticker_data = ticker_data.reset_index()
+
+                    # Skip if no data for this ticker
+                    if ticker_data.empty or ticker_data["Close"].isna().all():
+                        continue
+
+                    ticker_df = pl.from_pandas(ticker_data).select(
+                        pl.lit(ticker).alias("ticker"),
+                        pl.col("Date").dt.date().alias("date"),
+                        pl.col("Open").alias("open"),
+                        pl.col("High").alias("high"),
+                        pl.col("Low").alias("low"),
+                        pl.col("Close").alias("close"),
+                        pl.col("Volume").cast(pl.Float64).alias("volume"),
+                    )
+
+                    # Drop rows with null prices
+                    ticker_df = ticker_df.drop_nulls(subset=["close"])
+
+                    if not ticker_df.is_empty():
+                        all_data.append(ticker_df)
+
+                except Exception as e:
+                    logger.warning(f"Failed to process {ticker} in batch: {e}")
+                    continue
+
+        except Exception as e:
+            logger.error(f"Failed to fetch batch: {e}")
+            continue
+
+    if not all_data:
+        return pl.DataFrame(schema=_empty_schema())
+
+    return pl.concat(all_data).sort("date", "ticker")
 
 
-# @flow
-# def stock_prices_yfinance_daily_flow():
-#     last_market_date = get_last_market_date()
-#     yesterday = (dt.datetime.now(TIME_ZONE) - dt.timedelta(days=1)).date()
+@task
+def get_stock_prices_yfinance_by_year(
+    tickers: list[str], start: dt.datetime, end: dt.datetime
+) -> pl.DataFrame:
+    """
+    Fetch stock prices in batches by year.
+    """
+    logger = get_run_logger()
+    years = range(start.year, end.year + 1)
+    stock_prices_list = []
 
-#     # Only get new data if yesterday was the last market date
-#     if last_market_date != yesterday:
-#         print("Market was not open yesterday!")
-#         print("Last Market Date:", last_market_date)
-#         print("Yesterday:", yesterday)
-#         return
+    for year in years:
+        year_start = max(dt.datetime(year, 1, 1, 0, 0, 0, tzinfo=TIME_ZONE), start)
+        year_end = min(dt.datetime(year, 12, 31, 23, 59, 59, tzinfo=TIME_ZONE), end)
 
-#     start = dt.datetime.combine(yesterday, dt.time(0, 0, 0)).replace(tzinfo=TIME_ZONE)
-#     end = dt.datetime.combine(yesterday, dt.time(23, 59, 59)).replace(tzinfo=TIME_ZONE)
+        logger.info(f"Fetching year {year}: {year_start.date()} to {year_end.date()}")
 
-#     tickers = get_tickers()
-#     stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
-#     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
+        stock_prices = get_stock_prices_yfinance_batch(tickers, year_start, year_end)
+
+        if not stock_prices.is_empty():
+            stock_prices_list.append(stock_prices)
+
+    if not stock_prices_list:
+        return pl.DataFrame(schema=_empty_schema())
+
+    return (
+        pl.concat(stock_prices_list)
+        .unique(subset=["ticker", "date"])
+        .with_columns(pl.col("date").dt.year().alias("year"))
+        .sort("date", "ticker")
+    )
+
+
+@task
+def upload_and_merge_stock_prices_yfinance_df(stock_prices_df: pl.DataFrame):
+    bear_lake_client = get_bear_lake_client()
+    table_name = "stock_prices_yfinance"
+
+    # Create table if not exists
+    bear_lake_client.create(
+        name=table_name,
+        schema={
+            "ticker": pl.String,
+            "date": pl.Date,
+            "open": pl.Float64,
+            "high": pl.Float64,
+            "low": pl.Float64,
+            "close": pl.Float64,
+            "volume": pl.Float64,
+        },
+        partition_keys=["year"],
+        primary_keys=["date", "ticker"],
+        mode="skip",
+    )
+
+    # Insert into table
+    bear_lake_client.insert(name=table_name, data=stock_prices_df, mode="append")
+
+    # Optimize table (deduplicate)
+    bear_lake_client.optimize(name=table_name)
+
+
+@flow
+def stock_prices_yfinance_backfill_flow():
+    """
+    Grabbing yfinance data from 2000 to present day.
+    """
+    start = dt.datetime(2000, 1, 1, tzinfo=TIME_ZONE)
+    end = dt.datetime.now(TIME_ZONE) - dt.timedelta(days=1)
+
+    tickers = get_tickers()
+    stock_prices_df = get_stock_prices_yfinance_by_year(tickers, start, end)
+    upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
+
+
+@flow
+def stock_prices_yfinance_daily_flow():
+    last_market_date = get_last_market_date()
+    yesterday = (dt.datetime.now(TIME_ZONE) - dt.timedelta(days=1)).date()
+
+    # Only get new data if yesterday was the last market date
+    if last_market_date != yesterday:
+        print("Market was not open yesterday!")
+        print("Last Market Date:", last_market_date)
+        print("Yesterday:", yesterday)
+        return
+
+    start = dt.datetime.combine(yesterday, dt.time(0, 0, 0)).replace(tzinfo=TIME_ZONE)
+    end = dt.datetime.combine(yesterday, dt.time(23, 59, 59)).replace(tzinfo=TIME_ZONE)
+
+    tickers = get_tickers()
+    stock_prices_df = get_stock_prices_yfinance_by_year(tickers, start, end)
+    upload_and_merge_stock_prices_yfinance_df(stock_prices_df)

--- a/pipelines/stock_prices_yfinance_flow.py
+++ b/pipelines/stock_prices_yfinance_flow.py
@@ -1,248 +1,108 @@
+from clients import get_clickhouse_client
 import datetime as dt
-
-import bear_lake as bl
 import polars as pl
-import yfinance as yf
-from clients import get_bear_lake_client
-from prefect import flow, get_run_logger, task
-from utils import get_last_market_date
+from prefect import flow, task, get_run_logger
 from variables import TIME_ZONE
+import yfinance as yf
+from utils import get_last_market_date
 
 
-def _empty_schema() -> dict:
-    """Return the expected schema for an empty DataFrame."""
-    return {
-        "ticker": pl.String,
-        "date": pl.Date,
-        "open": pl.Float64,
-        "high": pl.Float64,
-        "low": pl.Float64,
-        "close": pl.Float64,
-        "volume": pl.Float64,
-    }
+def to_yfinance_ticker(ticker: str) -> str:
+    """Convert database ticker to yfinance format (BF.B -> BF-B)"""
+    return ticker.replace(".", "-")
+
+
+def to_db_ticker(yf_ticker: str) -> str:
+    """Convert yfinance ticker back to database format (BF-B -> BF.B)"""
+    return yf_ticker.replace("-", ".")
 
 
 @task
-def get_tickers_with_date_range() -> pl.DataFrame:
-    """Get tickers with their date ranges from universe."""
-    bear_lake_client = get_bear_lake_client()
-    return bear_lake_client.query(
-        bl.table("universe")
-        .group_by("ticker")
-        .agg(
-            bl.col("date").min().alias("min_date"),
-            bl.col("date").max().alias("max_date"),
-        )
+def get_tickers() -> list[str]:
+    clickhouse_client = get_clickhouse_client()
+
+    universe_arrow = clickhouse_client.query_arrow(
+        f"SELECT DISTINCT ticker FROM universe"
     )
+
+    return pl.from_arrow(universe_arrow)["ticker"].sort().to_list()
 
 
 @task
 def get_stock_prices_yfinance(
-    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime
+    tickers: list[str], start: dt.datetime, end: dt.datetime
 ) -> pl.DataFrame:
     """
     Fetch historical stock prices from yfinance.
-    Uses date ranges from universe to skip delisted tickers and cap end dates.
+    Returns data in the same schema as Alpaca, with vwap and trade_count as null.
     """
     logger = get_run_logger()
 
-    if tickers_df.is_empty():
-        return pl.DataFrame(schema=_empty_schema())
+    try:
+        # yfinance expects dates without timezone, so convert to naive datetime
+        start_naive = start.replace(tzinfo=None)
+        end_naive = end.replace(tzinfo=None)
 
-    # Convert to naive datetime (yfinance expects dates without timezone)
-    start_naive = start.replace(tzinfo=None)
-    end_naive = end.replace(tzinfo=None)
+        # Convert tickers to yfinance format (BF.B -> BF-B)
+        yf_tickers = [to_yfinance_ticker(t) for t in tickers]
 
-    all_data = []
-    skipped = 0
-    fetched = 0
+        # Download data for all tickers at once
+        data_raw = yf.download(tickers=yf_tickers, start=start_naive, end=end_naive)
 
-    for row in tickers_df.iter_rows(named=True):
-        ticker = row["ticker"]
-        max_date = row["max_date"]
+        if data_raw.empty:
+            return pl.DataFrame(
+                schema={
+                    "ticker": pl.String,
+                    "date": pl.String,
+                    "open": pl.Float64,
+                    "high": pl.Float64,
+                    "low": pl.Float64,
+                    "close": pl.Float64,
+                    "volume": pl.Float64,
+                }
+            )
 
-        # Skip if we're requesting data after this ticker was delisted
-        if start.date() > max_date:
-            skipped += 1
-            continue
+        # Stack and reset index to get long format
+        data_clean = data_raw.stack(future_stack=True).reset_index()
 
-        # Cap the end date to when the ticker was last active
-        effective_end_date = min(end.date(), max_date)
-        effective_end_naive = dt.datetime.combine(
-            effective_end_date, dt.time(23, 59, 59)
+        # Convert to polars
+        hist_df = pl.from_pandas(data_clean)
+
+        # Rename columns to match schema and convert tickers back to db format
+        stock_prices_clean = hist_df.select(
+            pl.col("Ticker").map_elements(to_db_ticker, return_dtype=pl.String).alias("ticker"),
+            pl.col("Date").dt.date().cast(pl.String).alias("date"),
+            pl.col("Open").alias("open"),
+            pl.col("High").alias("high"),
+            pl.col("Low").alias("low"),
+            pl.col("Close").alias("close"),
+            pl.col("Volume").cast(pl.Float64).alias("volume"),
         )
 
-        try:
-            # Download single ticker
-            data = yf.download(
-                tickers=ticker,
-                start=start_naive,
-                end=effective_end_naive,
-                progress=False,
-                auto_adjust=True,
-            )
+        return stock_prices_clean.sort("date", "ticker")
 
-            if data.empty:
-                continue
-
-            # Reset index to get Date as a column
-            data = data.reset_index()
-
-            # Convert to polars and add ticker column
-            ticker_df = pl.from_pandas(data).select(
-                pl.lit(ticker).alias("ticker"),
-                pl.col("Date").dt.date().alias("date"),
-                pl.col("Open").alias("open"),
-                pl.col("High").alias("high"),
-                pl.col("Low").alias("low"),
-                pl.col("Close").alias("close"),
-                pl.col("Volume").cast(pl.Float64).alias("volume"),
-            )
-
-            all_data.append(ticker_df)
-            fetched += 1
-
-        except Exception as e:
-            logger.warning(f"Failed to fetch {ticker}: {e}")
-            continue
-
-    logger.info(f"Fetched {fetched} tickers, skipped {skipped} delisted")
-
-    if not all_data:
-        return pl.DataFrame(schema=_empty_schema())
-
-    return pl.concat(all_data).sort("date", "ticker")
+    except Exception as e:
+        logger.error(f"Error fetching data: {e}")
+        return pl.DataFrame(
+            schema={
+                "ticker": pl.String,
+                "date": pl.String,
+                "open": pl.Float64,
+                "high": pl.Float64,
+                "low": pl.Float64,
+                "close": pl.Float64,
+                "volume": pl.Float64,
+            }
+        )
 
 
 @task
-def get_stock_prices_yfinance_batch(
-    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime, batch_size: int = 50
+def get_stock_prices_yfinance_batches(
+    tickers: list[str], start: dt.datetime, end: dt.datetime
 ) -> pl.DataFrame:
     """
-    Fetch stock prices using yf.download() with batched tickers.
-    Uses date ranges from universe to filter and cap dates appropriately.
+    Fetch stock prices in batches by year using yf.download().
     """
-    logger = get_run_logger()
-
-    if tickers_df.is_empty():
-        return pl.DataFrame(schema=_empty_schema())
-
-    start_naive = start.replace(tzinfo=None)
-    end_naive = end.replace(tzinfo=None)
-
-    # Filter to only tickers active during this period
-    active_tickers_df = tickers_df.filter(pl.col("max_date") >= start.date())
-    
-    if active_tickers_df.is_empty():
-        logger.info(f"No active tickers for period {start.date()} to {end.date()}")
-        return pl.DataFrame(schema=_empty_schema())
-
-    # Build a lookup for max_date by ticker
-    max_date_lookup = {
-        row["ticker"]: row["max_date"] 
-        for row in active_tickers_df.iter_rows(named=True)
-    }
-    
-    tickers = list(max_date_lookup.keys())
-    logger.info(f"Fetching {len(tickers)} active tickers (filtered from {len(tickers_df)})")
-
-    all_data = []
-
-    # Process in batches
-    for i in range(0, len(tickers), batch_size):
-        batch = tickers[i : i + batch_size]
-        logger.info(f"Fetching batch {i // batch_size + 1}: {len(batch)} tickers")
-
-        try:
-            # Download batch of tickers
-            data = yf.download(
-                tickers=batch,
-                start=start_naive,
-                end=end_naive,
-                progress=False,
-                auto_adjust=True,
-                group_by="ticker",
-            )
-
-            if data.empty:
-                continue
-
-            # Handle single ticker case (no MultiIndex)
-            if len(batch) == 1:
-                ticker = batch[0]
-                max_date = max_date_lookup[ticker]
-                data = data.reset_index()
-                
-                ticker_df = pl.from_pandas(data).select(
-                    pl.lit(ticker).alias("ticker"),
-                    pl.col("Date").dt.date().alias("date"),
-                    pl.col("Open").alias("open"),
-                    pl.col("High").alias("high"),
-                    pl.col("Low").alias("low"),
-                    pl.col("Close").alias("close"),
-                    pl.col("Volume").cast(pl.Float64).alias("volume"),
-                )
-                
-                # Filter to only dates up to max_date
-                ticker_df = ticker_df.filter(pl.col("date") <= max_date)
-                
-                if not ticker_df.is_empty():
-                    all_data.append(ticker_df)
-                continue
-
-            # Handle multiple tickers (MultiIndex columns grouped by ticker)
-            for ticker in batch:
-                try:
-                    if ticker not in data.columns.get_level_values(0):
-                        continue
-
-                    max_date = max_date_lookup[ticker]
-                    ticker_data = data[ticker].copy()
-                    ticker_data = ticker_data.reset_index()
-
-                    if ticker_data.empty or ticker_data["Close"].isna().all():
-                        continue
-
-                    ticker_df = pl.from_pandas(ticker_data).select(
-                        pl.lit(ticker).alias("ticker"),
-                        pl.col("Date").dt.date().alias("date"),
-                        pl.col("Open").alias("open"),
-                        pl.col("High").alias("high"),
-                        pl.col("Low").alias("low"),
-                        pl.col("Close").alias("close"),
-                        pl.col("Volume").cast(pl.Float64).alias("volume"),
-                    )
-
-                    # Filter to only dates up to max_date and drop nulls
-                    ticker_df = ticker_df.filter(pl.col("date") <= max_date).drop_nulls(
-                        subset=["close"]
-                    )
-
-                    if not ticker_df.is_empty():
-                        all_data.append(ticker_df)
-
-                except Exception as e:
-                    logger.warning(f"Failed to process {ticker} in batch: {e}")
-                    continue
-
-        except Exception as e:
-            logger.error(f"Failed to fetch batch: {e}")
-            continue
-
-    if not all_data:
-        return pl.DataFrame(schema=_empty_schema())
-
-    return pl.concat(all_data).sort("date", "ticker")
-
-
-@task
-def get_stock_prices_yfinance_by_year(
-    tickers_df: pl.DataFrame, start: dt.datetime, end: dt.datetime
-) -> pl.DataFrame:
-    """
-    Fetch stock prices in batches by year.
-    """
-    logger = get_run_logger()
     years = range(start.year, end.year + 1)
     stock_prices_list = []
 
@@ -250,64 +110,67 @@ def get_stock_prices_yfinance_by_year(
         year_start = max(dt.datetime(year, 1, 1, 0, 0, 0, tzinfo=TIME_ZONE), start)
         year_end = min(dt.datetime(year, 12, 31, 23, 59, 59, tzinfo=TIME_ZONE), end)
 
-        logger.info(f"Fetching year {year}: {year_start.date()} to {year_end.date()}")
-
-        stock_prices = get_stock_prices_yfinance_batch(tickers_df, year_start, year_end)
+        stock_prices = get_stock_prices_yfinance(tickers, year_start, year_end)
 
         if not stock_prices.is_empty():
             stock_prices_list.append(stock_prices)
 
     if not stock_prices_list:
-        return pl.DataFrame(schema=_empty_schema())
+        return pl.DataFrame(
+            schema={
+                "ticker": pl.String,
+                "date": pl.String,
+                "open": pl.Float64,
+                "high": pl.Float64,
+                "low": pl.Float64,
+                "close": pl.Float64,
+                "volume": pl.Float64,
+            }
+        )
 
-    return (
-        pl.concat(stock_prices_list)
-        .unique(subset=["ticker", "date"])
-        .with_columns(pl.col("date").dt.year().alias("year"))
-        .sort("date", "ticker")
-    )
+    return pl.concat(stock_prices_list).sort("date", "ticker")
 
 
+# based on existing patterns in other jobs
 @task
 def upload_and_merge_stock_prices_yfinance_df(stock_prices_df: pl.DataFrame):
-    bear_lake_client = get_bear_lake_client()
+    clickhouse_client = get_clickhouse_client()
     table_name = "stock_prices_yfinance"
 
     # Create table if not exists
-    bear_lake_client.create(
-        name=table_name,
-        schema={
-            "ticker": pl.String,
-            "date": pl.Date,
-            "open": pl.Float64,
-            "high": pl.Float64,
-            "low": pl.Float64,
-            "close": pl.Float64,
-            "volume": pl.Float64,
-        },
-        partition_keys=["year"],
-        primary_keys=["date", "ticker"],
-        mode="skip",
+    clickhouse_client.command(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            ticker String,
+            date String,
+            open Float64,
+            high Float64,
+            low Float64,
+            close Float64,
+            volume Float64
+        )
+        ENGINE = ReplacingMergeTree()
+        ORDER BY (ticker, date)
+        """
     )
 
     # Insert into table
-    bear_lake_client.insert(name=table_name, data=stock_prices_df, mode="append")
+    clickhouse_client.insert_df_arrow(table_name, stock_prices_df)
 
     # Optimize table (deduplicate)
-    bear_lake_client.optimize(name=table_name)
+    clickhouse_client.command(f"OPTIMIZE TABLE {table_name} FINAL")
 
 
 @flow
 def stock_prices_yfinance_backfill_flow():
     """
     Grabbing yfinance data from 2000 to present day.
-    Uses universe date ranges to avoid fetching data for delisted tickers.
     """
     start = dt.datetime(2000, 1, 1, tzinfo=TIME_ZONE)
-    end = dt.datetime.now(TIME_ZONE) - dt.timedelta(days=1)
+    end = dt.datetime.now(TIME_ZONE)
 
-    tickers_df = get_tickers_with_date_range()
-    stock_prices_df = get_stock_prices_yfinance_by_year(tickers_df, start, end)
+    tickers = get_tickers()
+    stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
 
 
@@ -326,6 +189,6 @@ def stock_prices_yfinance_daily_flow():
     start = dt.datetime.combine(yesterday, dt.time(0, 0, 0)).replace(tzinfo=TIME_ZONE)
     end = dt.datetime.combine(yesterday, dt.time(23, 59, 59)).replace(tzinfo=TIME_ZONE)
 
-    tickers_df = get_tickers_with_date_range()
-    stock_prices_df = get_stock_prices_yfinance_by_year(tickers_df, start, end)
+    tickers = get_tickers()
+    stock_prices_df = get_stock_prices_yfinance_batches(tickers, start, end)
     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)

--- a/pipelines/stock_prices_yfinance_flow.py
+++ b/pipelines/stock_prices_yfinance_flow.py
@@ -40,8 +40,8 @@ def get_tickers_with_date_range() -> pl.DataFrame:
         bl.table("universe")
         .group_by("ticker")
         .agg(
-            bl.col("date").min().alias("min_date"),
-            bl.col("date").max().alias("max_date"),
+            pl.col("date").min().alias("min_date"),
+            pl.col("date").max().alias("max_date"),
         )
     )
 
@@ -344,3 +344,14 @@ def stock_prices_yfinance_daily_flow():
     tickers_df = get_tickers_with_date_range()
     stock_prices_df = get_stock_prices_yfinance_by_year(tickers_df, start, end)
     upload_and_merge_stock_prices_yfinance_df(stock_prices_df)
+
+if __name__ == '__main__':
+    from rich import print
+    bear_lake_client = get_bear_lake_client()
+    bear_lake_client.drop('stock_prices_yfinance')
+
+    stock_prices_yfinance_backfill_flow()
+
+    print(bear_lake_client.query(
+        bl.table('stock_prices_yfinance')
+    ))


### PR DESCRIPTION
## Problem
The `yf.download()` function with multiple tickers returns a MultiIndex DataFrame that wasn't being parsed correctly. The old code used `.stack(future_stack=True)` which doesn't work reliably with yfinance's column structure.

## Solution
Rewrote the flow with proper handling:

### Key Changes
- ✅ **Updated to bear_lake client** — Matches the working `stock_prices_flow.py` pattern
- ✅ **Fixed MultiIndex handling** — Uses `group_by='ticker'` and processes each ticker from the grouped structure
- ✅ **Added batched downloading** — 50 tickers at a time to avoid API rate limits
- ✅ **Robust error handling** — Individual ticker failures are logged but don't break the flow
- ✅ **Proper date types** — Changed from `pl.String` to `pl.Date` for consistency
- ✅ **Year partitioning** — Added `year` column for efficient partitioning
- ✅ **Adjusted prices** — Uses `auto_adjust=True` for split/dividend adjusted data

### Functions
- `get_stock_prices_yfinance()` — Downloads individual tickers (most reliable)
- `get_stock_prices_yfinance_batch()` — Downloads in batches with proper MultiIndex parsing
- `get_stock_prices_yfinance_by_year()` — Batches by year for large backfills

## Testing
Ready to run `stock_prices_yfinance_backfill_flow()` for the full backfill from 2000.